### PR TITLE
Windows specific bug fix with index.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function bundle() {
 		for (let i = 0; i < lines.length; i++) {
 			const imp = lines[i].match(/^(\s*)import ((.+) from )?['"](.+)['"]/)
 			if (imp) {
-				// Somehow this line worked different on Windows, so I changed to a bit better approach
+				// Somehow this line wasn't working the right way on Windows
 				// let p = Path.join(path.split("/").slice(0, -1).join("/"), imp[4])
 				const dir = Path.dirname(path);
 				let p = Path.join(dir, imp[4]).replaceAll("\\", "/");

--- a/index.js
+++ b/index.js
@@ -53,7 +53,11 @@ function bundle() {
 		for (let i = 0; i < lines.length; i++) {
 			const imp = lines[i].match(/^(\s*)import ((.+) from )?['"](.+)['"]/)
 			if (imp) {
-				let p = Path.join(path.split("/").slice(0, -1).join("/"), imp[4])
+				// Somehow this line worked different on Windows, so I changed to a bit better approach
+				// let p = Path.join(path.split("/").slice(0, -1).join("/"), imp[4])
+				const dir = Path.dirname(path);
+				let p = Path.join(dir, imp[4]).replaceAll("\\", "/");
+				
 				if (p.endsWith(".css")) {
 					lines[i] = "// " + lines[i]
 					cssFiles.push(p)

--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ function bundle() {
 				// Somehow this line wasn't working the right way on Windows
 				// let p = Path.join(path.split("/").slice(0, -1).join("/"), imp[4])
 				const dir = Path.dirname(path);
-				let p = Path.join(dir, imp[4]).replaceAll("\\", "/");
+				let p = Path.normalize(Path.join(dir, imp[4]));
+				console.log(p);
 				
 				if (p.endsWith(".css")) {
 					lines[i] = "// " + lines[i]


### PR DESCRIPTION
When running the command `node index.js` on Windows, the following error occurs:

![image](https://github.com/user-attachments/assets/a25ff1b2-5bb5-4dd6-bda2-bef215d32d84)

This issue arises because the joined path in index.js (specifically line 56) doesn't have the same outcome on Windows compared to Linux.
```javascript
let p = Path.join(path.split("/").slice(0, -1).join("/"), imp[4])
```
When I print out its value there is a clear difference between Linux and Windows.
### Ubuntu
![image](https://github.com/user-attachments/assets/111eff6a-9f41-4f97-aace-62e9decb5751)
### Windows
![image](https://github.com/user-attachments/assets/42c6fc97-e54d-4a49-9a3f-a880c3b08b10)
I resolved this issue by replacing the manual path splitting with Path.dirname() to ensure cross-platform compatibility. Here's the replacement code:
```javascript
const dir = Path.dirname(path);
let p = Path.normalize(Path.join(dir, imp[4]));
```