### PR TITLE
Fix build path error

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function bundle() {
 			const imp = lines[i].match(/^(\s*)import ((.+) from )?['"](.+)['"]/)
 			if (imp) {
 				const dir = Path.dirname(path)
-				let p = Path.normalize(Path.join(dir, imp[4]))
+				let p = Path.normalize(Path.join(dir, imp[4])).replaceAll('\\', '/');
 				
 				if (p.endsWith(".css")) {
 					lines[i] = "// " + lines[i]


### PR DESCRIPTION
Previously in `index.js` file, almost every file's path had backslashes. This caused the index.html to generate incorrectly. Now it has slashes and that fixed the issue.

I changed only one line.

### Before
```js
let p = Path.normalize(Path.join(dir, imp[4]));
```

### After
```js
let p = Path.normalize(Path.join(dir, imp[4])).replaceAll('\\', '/');
```